### PR TITLE
Pidgin mit Gajim ersetzt

### DIFF
--- a/TeX/web.tex
+++ b/TeX/web.tex
@@ -18,10 +18,10 @@
 {GPL, LGPL, MPL}
 {ja}
 
-\software{Pidgin}{Instant-Messenger}
-{Multi-Protokoll-Client für verschiedene Instant-Messenger-Dienste wie \mbox{Google} Talk, XMPP/Jabber, Facebook Chat, uvm. Ermöglicht Verschlüsselung mit OTR.}
+\software{Gajim}{Instant-Messenger}
+{Client für XMPP und Google Talk sowie weiterer Dienste über XMPP-Transports. Er unterstützt auch die E2E-Verschlüsselung OMEMO (Signal-Protokoll). }
 {Windows, GNU/Linux u.\,a.}
-{https://pidgin.im}
+{https://gajim.org/}
 {GPL}
 {ja}
 


### PR DESCRIPTION
Gajim unterstützt auch OMEMO, und die integrierte Facebook-Unterstützung von Pidgin hat die mittlerweile abgeschaltete XMPP-Schnittstelle von Facebook benutzt. 
Das PDF habe ich nicht geupdated, nur das TeX.